### PR TITLE
feat: support embedding urls using a vanity domain

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,4 +1,4 @@
-# Omni SDK 
+# Omni SDK
 
 **Unofficial  SDK for [Omni Analytics](https://omni.co/)**
 
@@ -16,11 +16,12 @@
 
 ## Configuration
 
-The following environment variables can be set to automatically configure classes so that kwargs do not need to be pass on creation.
+The following environment variables can be set to automatically configure classes so that kwargs do not need to be pass on creation. If you use `OMNI_VANITY_DOMAIN`, you do not need to configure an `OMNI_ORGANIZATION_NAME`.
 
 | Env Var | Description | Example |
 | --- | --- | --- |
 | OMNI_ORGANIZATION_NAME | Name of your Omni organization. Can be found in Admin -> Settings -> General in the Omni UI | acme |
+| OMNI_VANITY_DOMAIN | Vanity Domain for your Omni instance. | reporting.example.com |
 | OMNI_EMBED_SECRET | Secret key for created dashboard embed urls. Can be found in Admin -> Embed -> Admin. | vglUd1WblfyBSdBSMPj0KrxZcNUEZ1CC |
 
 ## Usage

--- a/src/omni/embed.py
+++ b/src/omni/embed.py
@@ -5,7 +5,7 @@ import hashlib
 import hmac
 import urllib.parse
 import uuid
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from enum import Enum
 
 from .env import OmniEnv
@@ -56,22 +56,25 @@ class OmniDashboardEmbedder:
         blank = "blank"
 
     def __init__(
-        self, organization_name: str | None = None, embed_secret: str | None = None
+        self,
+        organization_name: str | None = None,
+        embed_secret: str | None = None,
+        vanity_domain: str | None = None,
     ):
         _organization_name = organization_name or OmniEnv.ORGANIZATION_NAME
-        if not _organization_name:
-            raise ValueError(
-                "organization_name is required if it is not configured in environment variables."
-            )
+        _vanity_domain = vanity_domain or OmniEnv.VANITY_DOMAIN
+        if not (_organization_name or _vanity_domain):
+            raise ValueError("'vanity_domain' or 'organization_name' are required.")
         _embed_secret = embed_secret or OmniEnv.EMBED_SECRET
         if not _embed_secret:
             raise ValueError(
                 "embed_secret is required if it is not configured in environment variables."
             )
 
-        self.embed_login_url = (
-            f"https://{_organization_name}.embed-omniapp.co/embed/login"
+        embed_host = (
+            vanity_domain if vanity_domain else f"{_organization_name}.embed-omniapp.co"
         )
+        self.embed_login_url = f"https://{embed_host}/embed/login"
         self.embed_secret = _embed_secret
 
     def build_url(

--- a/src/omni/embed.py
+++ b/src/omni/embed.py
@@ -71,9 +71,7 @@ class OmniDashboardEmbedder:
                 "embed_secret is required if it is not configured in environment variables."
             )
 
-        embed_host = (
-            vanity_domain if vanity_domain else f"{_organization_name}.embed-omniapp.co"
-        )
+        embed_host = _vanity_domain or f"{_organization_name}.embed-omniapp.co"
         self.embed_login_url = f"https://{embed_host}/embed/login"
         self.embed_secret = _embed_secret
 

--- a/src/omni/env.py
+++ b/src/omni/env.py
@@ -11,6 +11,14 @@ class __OmniEnv:
         return os.environ.get("OMNI_ORGANIZATION_NAME")
 
     @property
+    def VANITY_DOMAIN(self) -> str | None:
+        """Configured Omni vanity domain (https://docs.omni.co/docs/embed/private-embedding#use-a-vanity-domain)
+
+        Expects host, e.g. if vanity domain is https://foo.example.com, value should be 'foo.example.com'
+        """
+        return os.environ.get("OMNI_VANITY_DOMAIN")
+
+    @property
     def EMBED_SECRET(self) -> str | None:
         return os.environ.get("OMNI_EMBED_SECRET")
 

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -8,13 +8,20 @@ def embedder():
     return OmniDashboardEmbedder(organization_name="acme", embed_secret="super_secret")
 
 
+@pytest.fixture
+def vanity_domain_embedder():
+    return OmniDashboardEmbedder(
+        vanity_domain="foo.example.com", embed_secret="super_secret"
+    )
+
+
 @pytest.fixture(autouse=True)
 def patch_uuid(monkeypatch):
     monkeypatch.setattr("uuid.UUID.hex", "365f7003aa5b4f3586d9b81b4a5d9f69")
 
 
 class TestEmbed:
-    def test_basic_url(self, embedder):
+    def test_basic_url(self, embedder, vanity_domain_embedder):
         url = embedder.build_url(
             content_path="/dashboards/da24491e",
             external_id="1",
@@ -25,7 +32,17 @@ class TestEmbed:
             == "https://acme.embed-omniapp.co/embed/login?contentPath=%2Fdashboards%2Fda24491e&externalId=1&name=Somebody&nonce=365f7003aa5b4f3586d9b81b4a5d9f69&signature=mToqUfdkmVSyDIGAl6Ggs9uAmGQAH9OzbbCZ-xgEU8c%3D"
         )
 
-    def test_kitchen_sink(self, embedder):
+        url = vanity_domain_embedder.build_url(
+            content_path="/dashboards/da24491e",
+            external_id="1",
+            name="Somebody",
+        )
+        assert (
+            url
+            == "https://foo.example.com/embed/login?contentPath=%2Fdashboards%2Fda24491e&externalId=1&name=Somebody&nonce=365f7003aa5b4f3586d9b81b4a5d9f69&signature=8HSOH-lXN3pJJ3FiaAw1XFhLCdzL44RtFS7z9S8thug%3D"
+        )
+
+    def test_kitchen_sink(self, embedder, vanity_domain_embedder):
         url = embedder.build_url(
             content_path="/dashboards/da24491e",
             external_id="1",
@@ -57,7 +74,38 @@ class TestEmbed:
             "&signature=Y8Alg2Sfdi5WdbwzU4QEugs3HdwLfEvXuBv8UU3BBZw%3D"
         )
 
-    def test_link_access(self, embedder):
+        url = vanity_domain_embedder.build_url(
+            content_path="/dashboards/da24491e",
+            external_id="1",
+            name="Somebody",
+            custom_theme={
+                "dashboard-background": "#00FF00",
+                "dashboard-tile-background": "#00FF00",
+            },
+            entity="Acme",
+            filter_search_params={"state": "GA"},
+            link_access=True,
+            prefers_dark=OmniDashboardEmbedder.PrefersDark.yes,
+            theme=OmniDashboardEmbedder.Theme.dawn,
+            user_attributes={"country": "USA"},
+        )
+        assert url == (
+            "https://foo.example.com/embed/login?"
+            "contentPath=%2Fdashboards%2Fda24491e"
+            "&externalId=1"
+            "&name=Somebody"
+            "&nonce=365f7003aa5b4f3586d9b81b4a5d9f69"
+            "&customTheme=%7B%22dashboard-background%22%3A%22%2300FF00%22%2C%22dashboard-tile-background%22%3A%22%2300FF00%22%7D"
+            "&entity=Acme"
+            "&filterSearchParam=state%3DGA"
+            "&linkAccess=__omni_link_access_open"
+            "&prefersDark=true"
+            "&theme=dawn"
+            "&userAttributes=%7B%22country%22%3A%22USA%22%7D"
+            "&signature=UFgVTk9HVXtEzbuoEBgvFaG1DvUdYVBJbfvfnE25WYY%3D"
+        )
+
+    def test_link_access(self, embedder, vanity_domain_embedder):
         url = embedder.build_url(
             content_path="/dashboards/da24491e",
             external_id="1",
@@ -77,6 +125,27 @@ class TestEmbed:
         assert (
             url
             == "https://acme.embed-omniapp.co/embed/login?contentPath=%2Fdashboards%2Fda24491e&externalId=1&name=Somebody&nonce=365f7003aa5b4f3586d9b81b4a5d9f69&linkAccess=abcd1234%2Cefgh5678&signature=rKpBYpOKIVQmCXNfhB7J8Z0WYnlELI5KmH4uPHc1048%3D"
+        )
+
+        url = vanity_domain_embedder.build_url(
+            content_path="/dashboards/da24491e",
+            external_id="1",
+            name="Somebody",
+            link_access=True,
+        )
+        assert (
+            url
+            == "https://foo.example.com/embed/login?contentPath=%2Fdashboards%2Fda24491e&externalId=1&name=Somebody&nonce=365f7003aa5b4f3586d9b81b4a5d9f69&linkAccess=__omni_link_access_open&signature=7tFx5JlpXvJCW0llSTTioLWg53m5iGQCKKn1Yz9EO2o%3D"
+        )
+        url = vanity_domain_embedder.build_url(
+            content_path="/dashboards/da24491e",
+            external_id="1",
+            name="Somebody",
+            link_access=["abcd1234", "efgh5678"],
+        )
+        assert (
+            url
+            == "https://foo.example.com/embed/login?contentPath=%2Fdashboards%2Fda24491e&externalId=1&name=Somebody&nonce=365f7003aa5b4f3586d9b81b4a5d9f69&linkAccess=abcd1234%2Cefgh5678&signature=UycR_auXAIHGVTDPahgMSt4NOUxDEVc92Y3ollHcU5Q%3D"
         )
 
     def test_filter_search_params(self, embedder):
@@ -109,7 +178,7 @@ class TestEmbed:
             == "https://acme.embed-omniapp.co/embed/login?contentPath=%2Fdashboards%2Fda24491e&externalId=1&name=Somebody&nonce=365f7003aa5b4f3586d9b81b4a5d9f69&signature=mToqUfdkmVSyDIGAl6Ggs9uAmGQAH9OzbbCZ-xgEU8c%3D"
         )
 
-    def test_missing_organization_name(self):
+    def test_missing_organization_name_or_vanity_domain(self):
         with pytest.raises(ValueError):
             OmniDashboardEmbedder(embed_secret="super_secret")
 
@@ -117,7 +186,15 @@ class TestEmbed:
         with pytest.raises(ValueError):
             OmniDashboardEmbedder(organization_name="acme")
 
-    def test_env_configuration(self, monkeypatch):
+        with pytest.raises(ValueError):
+            OmniDashboardEmbedder(vanity_domain="foo.example.com")
+
+    def test_env_configuration_with_organization(self, monkeypatch):
         monkeypatch.setenv("OMNI_ORGANIZATION_NAME", "acme")
+        monkeypatch.setenv("OMNI_EMBED_SECRET", "super_secret")
+        OmniDashboardEmbedder()
+
+    def test_env_configuration_with_vanity_domain(self, monkeypatch):
+        monkeypatch.setenv("OMNI_VANITY_DOMAIN", "foo.example.com")
         monkeypatch.setenv("OMNI_EMBED_SECRET", "super_secret")
         OmniDashboardEmbedder()


### PR DESCRIPTION
Adds support to the SDK for Omni custom vanity domains. Initial SDK release had hardcoded the Omni co domain based on the organization name.

Usage: 

```
OmniDashboardEmbedder(
  vanity_domain="foo.example.com", embed_secret="super_secret"
)
```